### PR TITLE
dont require openrouter url

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,12 +356,23 @@ type GeminiConfig struct {
 ```go
 type OpenRouterConfig struct {
 	APIKey       string
-	URL          string
 	Models       []string
 	MaxDailyReqs int
 	Referer      string
 	XTitle       string
 	Timeout      time.Duration
+}
+```
+
+**Example:**
+```go
+cfg := gollmrouter.OpenRouterConfig{
+    APIKey:       apiKey,
+    Models:       []string{"mistralai/mistral-7b-instruct:free"},
+    MaxDailyReqs: 1000,
+    Referer:      "https://myapp.com",
+    XTitle:       "My App",
+    Timeout:      30 * time.Second,
 }
 ```
 
@@ -376,6 +387,8 @@ type FunctionCallingConfig struct {
 	ToolExecutor ToolExecutor
 }
 ```
+
+
 
 ### Helper Functions
 

--- a/examples/mcp_example.go
+++ b/examples/mcp_example.go
@@ -41,7 +41,6 @@ func main() {
 	// Create OpenRouter provider as fallback (also supports function calling)
 	openRouterProvider, err := gollmrouter.NewOpenRouterProvider(gollmrouter.OpenRouterConfig{
 		APIKey:       "your-openrouter-api-key",
-		URL:          "https://openrouter.ai/api/v1/chat/completions",
 		Models:       []string{"openai/gpt-4", "openai/gpt-3.5-turbo"},
 		MaxDailyReqs: 100,
 		Referer:      "your-app",

--- a/providers.go
+++ b/providers.go
@@ -13,6 +13,11 @@ import (
 	"github.com/FramnkRulez/go-llm-router/provider"
 )
 
+// Common API endpoints
+const (
+	OpenRouterAPIEndpoint = "https://openrouter.ai/api/v1/chat/completions"
+)
+
 // FileAttachment represents a file attachment with metadata and data
 type FileAttachment = provider.File
 
@@ -53,7 +58,6 @@ type GeminiConfig struct {
 // OpenRouterConfig holds configuration for creating an OpenRouter provider
 type OpenRouterConfig struct {
 	APIKey       string
-	URL          string
 	Models       []string
 	MaxDailyReqs int
 	Referer      string
@@ -86,7 +90,7 @@ func NewOpenRouterProvider(config OpenRouterConfig) (provider.Provider, error) {
 
 	return providers.NewOpenRouterProvider(
 		config.APIKey,
-		config.URL,
+		OpenRouterAPIEndpoint,
 		config.Timeout,
 		config.Models,
 		config.Referer,


### PR DESCRIPTION
Fixed OpenRouter provider so that it doesn't require the URL to be passed in